### PR TITLE
fix: set `recolor` to true

### DIFF
--- a/src/catppuccin-frappe
+++ b/src/catppuccin-frappe
@@ -21,6 +21,7 @@ set notification-warning-fg	  "#FAE3B0"
 set inputbar-fg			          "#C6D0F5"
 set inputbar-bg 		          "#414559"
 
+set recolor                   "true"
 set recolor-lightcolor		    "#303446"
 set recolor-darkcolor		      "#C6D0F5"
 

--- a/src/catppuccin-latte
+++ b/src/catppuccin-latte
@@ -21,6 +21,7 @@ set notification-warning-fg	  "#FAE3B0"
 set inputbar-fg			          "#4C4F69"
 set inputbar-bg 		          "#CCD0DA"
 
+set recolor                   "true"
 set recolor-lightcolor		    "#EFF1F5"
 set recolor-darkcolor		      "#4C4F69"
 

--- a/src/catppuccin-macchiato
+++ b/src/catppuccin-macchiato
@@ -21,6 +21,7 @@ set notification-warning-fg	  "#FAE3B0"
 set inputbar-fg			          "#CAD3F5"
 set inputbar-bg 		          "#363A4F"
 
+set recolor                   "true"
 set recolor-lightcolor		    "#24273A"
 set recolor-darkcolor		      "#CAD3F5"
 

--- a/src/catppuccin-mocha
+++ b/src/catppuccin-mocha
@@ -21,6 +21,7 @@ set notification-warning-fg	  "#FAE3B0"
 set inputbar-fg			          "#CDD6F4"
 set inputbar-bg 		          "#313244"
 
+set recolor                   "true"
 set recolor-lightcolor		    "#1E1E2E"
 set recolor-darkcolor		      "#CDD6F4"
 


### PR DESCRIPTION
* set the recolor option to true to recolor pages by default 

I was wondering why the pages where still white after I added the theme to my config and then I found out that you have to set the option recolor to true to recolor the pages. 