### PR TITLE
edited recolor option to true

### DIFF
--- a/src/catppuccin-frappe
+++ b/src/catppuccin-frappe
@@ -1,3 +1,5 @@
+set recolor true
+
 set default-fg                "#C6D0F5"
 set default-bg 			          "#303446"
 

--- a/src/catppuccin-latte
+++ b/src/catppuccin-latte
@@ -1,3 +1,5 @@
+set recolor true
+
 set default-fg                "#4C4F69"
 set default-bg 			          "#EFF1F5"
 

--- a/src/catppuccin-macchiato
+++ b/src/catppuccin-macchiato
@@ -1,3 +1,5 @@
+set recolor true
+
 set default-fg                "#CAD3F5"
 set default-bg 			          "#24273A"
 

--- a/src/catppuccin-mocha
+++ b/src/catppuccin-mocha
@@ -1,3 +1,5 @@
+set recolor true
+
 set default-fg                "#CDD6F4"
 set default-bg 			          "#1E1E2E"
 


### PR DESCRIPTION
The boolean "recolor" by default is set to "false" which made the recoloring of all 4 Catppuccin flavors not work. By simply adding the 1 line: `set recolor true`, the recoloring worked once again. 

Thanks for your work on this!

This is also my first PR, so I might've done something wrong, please let me know!

