### PR TITLE
Change all HEX color values to RGBA. Enable 50% transparency on highlight values

### DIFF
--- a/src/catppuccin-frappe
+++ b/src/catppuccin-frappe
@@ -1,38 +1,38 @@
-set default-fg                "#C6D0F5"
-set default-bg 			          "#303446"
+set default-fg                rgba(198,208,245,1)
+set default-bg 			          rgba(48,52,70,1)
 
-set completion-bg		          "#414559"
-set completion-fg		          "#C6D0F5"
-set completion-highlight-bg	  "#575268"
-set completion-highlight-fg	  "#C6D0F5"
-set completion-group-bg		    "#414559"
-set completion-group-fg		    "#8CAAEE"
+set completion-bg		          rgba(65,69,89,1)
+set completion-fg		          rgba(198,208,245,1)
+set completion-highlight-bg	  rgba(87,82,104,1)
+set completion-highlight-fg	  rgba(198,208,245,1)
+set completion-group-bg		    rgba(65,69,89,1)
+set completion-group-fg		    rgba(140,170,238,1)
 
-set statusbar-fg		          "#C6D0F5"
-set statusbar-bg		          "#414559"
+set statusbar-fg		          rgba(198,208,245,1)
+set statusbar-bg		          rgba(65,69,89,1)
 
-set notification-bg		        "#414559"
-set notification-fg		        "#C6D0F5"
-set notification-error-bg	    "#414559"
-set notification-error-fg	    "#E78284"
-set notification-warning-bg	  "#414559"
-set notification-warning-fg	  "#FAE3B0"
+set notification-bg		        rgba(65,69,89,1)
+set notification-fg		        rgba(198,208,245,1)
+set notification-error-bg	    rgba(65,69,89,1)
+set notification-error-fg	    rgba(231,130,132,1)
+set notification-warning-bg	  rgba(65,69,89,1)
+set notification-warning-fg	  rgba(250,227,176,1)
 
-set inputbar-fg			          "#C6D0F5"
-set inputbar-bg 		          "#414559"
+set inputbar-fg			          rgba(198,208,245,1)
+set inputbar-bg 		          rgba(65,69,89,1)
 
 set recolor                   "true"
-set recolor-lightcolor		    "#303446"
-set recolor-darkcolor		      "#C6D0F5"
+set recolor-lightcolor		    rgba(48,52,70,1)
+set recolor-darkcolor		      rgba(198,208,245,1)
 
-set index-fg			            "#C6D0F5"
-set index-bg			            "#303446"
-set index-active-fg		        "#C6D0F5"
-set index-active-bg		        "#414559"
+set index-fg			            rgba(198,208,245,1)
+set index-bg			            rgba(48,52,70,1)
+set index-active-fg		        rgba(198,208,245,1)
+set index-active-bg		        rgba(65,69,89,1)
 
-set render-loading-bg		      "#303446"
-set render-loading-fg		      "#C6D0F5"
+set render-loading-bg		      rgba(48,52,70,1)
+set render-loading-fg		      rgba(198,208,245,1)
 
-set highlight-color		        "#575268"
-set highlight-fg              "#F4B8E4"
-set highlight-active-color	  "#F4B8E4"
+set highlight-color		        rgba(87,82,104,0.5)
+set highlight-fg              rgba(244,184,228,0.5)
+set highlight-active-color	  rgba(244,184,228,0.5)

--- a/src/catppuccin-latte
+++ b/src/catppuccin-latte
@@ -1,38 +1,38 @@
-set default-fg                "#4C4F69"
-set default-bg 			          "#EFF1F5"
+set default-fg                rgba(76,79,105,1)
+set default-bg 			          rgba(239,241,245,1)
 
-set completion-bg		          "#CCD0DA"
-set completion-fg		          "#4C4F69"
-set completion-highlight-bg	  "#575268"
-set completion-highlight-fg	  "#4C4F69"
-set completion-group-bg		    "#CCD0DA"
-set completion-group-fg		    "#1E66F5"
+set completion-bg		          rgba(204,208,218,1)
+set completion-fg		          rgba(76,79,105,1)
+set completion-highlight-bg	  rgba(87,82,104,1)
+set completion-highlight-fg	  rgba(76,79,105,1)
+set completion-group-bg		    rgba(204,208,218,1)
+set completion-group-fg		    rgba(30,102,245,1)
 
-set statusbar-fg		          "#4C4F69"
-set statusbar-bg		          "#CCD0DA"
+set statusbar-fg		          rgba(76,79,105,1)
+set statusbar-bg		          rgba(204,208,218,1)
 
-set notification-bg		        "#CCD0DA"
-set notification-fg		        "#4C4F69"
-set notification-error-bg	    "#CCD0DA"
-set notification-error-fg	    "#D20F39"
-set notification-warning-bg	  "#CCD0DA"
-set notification-warning-fg	  "#FAE3B0"
+set notification-bg		        rgba(204,208,218,1)
+set notification-fg		        rgba(76,79,105,1)
+set notification-error-bg	    rgba(204,208,218,1)
+set notification-error-fg	    rgba(210,15,57,1)
+set notification-warning-bg	  rgba(204,208,218,1)
+set notification-warning-fg	  rgba(250,227,176,1)
 
-set inputbar-fg			          "#4C4F69"
-set inputbar-bg 		          "#CCD0DA"
+set inputbar-fg			          rgba(76,79,105,1)
+set inputbar-bg 		          rgba(204,208,218,1)
 
 set recolor                   "true"
-set recolor-lightcolor		    "#EFF1F5"
-set recolor-darkcolor		      "#4C4F69"
+set recolor-lightcolor		    rgba(239,241,245,1)
+set recolor-darkcolor		      rgba(76,79,105,1)
 
-set index-fg			            "#4C4F69"
-set index-bg			            "#EFF1F5"
-set index-active-fg		        "#4C4F69"
-set index-active-bg		        "#CCD0DA"
+set index-fg			            rgba(76,79,105,1)
+set index-bg			            rgba(239,241,245,1)
+set index-active-fg		        rgba(76,79,105,1)
+set index-active-bg		        rgba(204,208,218,1)
 
-set render-loading-bg		      "#EFF1F5"
-set render-loading-fg		      "#4C4F69"
+set render-loading-bg		      rgba(239,241,245,1)
+set render-loading-fg		      rgba(76,79,105,1)
 
-set highlight-color		        "#575268"
-set highlight-fg              "#EA76CB"
-set highlight-active-color	  "#EA76CB"
+set highlight-color		        rgba(87,82,104,0.5)
+set highlight-fg              rgba(234,118,203,0.5)
+set highlight-active-color	  rgba(234,118,203,0.5)

--- a/src/catppuccin-macchiato
+++ b/src/catppuccin-macchiato
@@ -1,38 +1,38 @@
-set default-fg                "#CAD3F5"
-set default-bg 			          "#24273A"
+set default-fg                rgba(202,211,245,1)
+set default-bg 			          rgba(36,39,58,1)
 
-set completion-bg		          "#363A4F"
-set completion-fg		          "#CAD3F5"
-set completion-highlight-bg	  "#575268"
-set completion-highlight-fg	  "#CAD3F5"
-set completion-group-bg		    "#363A4F"
-set completion-group-fg		    "#8AADF4"
+set completion-bg		          rgba(54,58,79,1)
+set completion-fg		          rgba(202,211,245,1)
+set completion-highlight-bg	  rgba(87,82,104,1)
+set completion-highlight-fg	  rgba(202,211,245,1)
+set completion-group-bg		    rgba(54,58,79,1)
+set completion-group-fg		    rgba(138,173,244,1)
 
-set statusbar-fg		          "#CAD3F5"
-set statusbar-bg		          "#363A4F"
+set statusbar-fg		          rgba(202,211,245,1)
+set statusbar-bg		          rgba(54,58,79,1)
 
-set notification-bg		        "#363A4F"
-set notification-fg		        "#CAD3F5"
-set notification-error-bg	    "#363A4F"
-set notification-error-fg	    "#ED8796"
-set notification-warning-bg	  "#363A4F"
-set notification-warning-fg	  "#FAE3B0"
+set notification-bg		        rgba(54,58,79,1)
+set notification-fg		        rgba(202,211,245,1)
+set notification-error-bg	    rgba(54,58,79,1)
+set notification-error-fg	    rgba(237,135,150,1)
+set notification-warning-bg	  rgba(54,58,79,1)
+set notification-warning-fg	  rgba(250,227,176,1)
 
-set inputbar-fg			          "#CAD3F5"
-set inputbar-bg 		          "#363A4F"
+set inputbar-fg			          rgba(202,211,245,1)
+set inputbar-bg 		          rgba(54,58,79,1)
 
 set recolor                   "true"
-set recolor-lightcolor		    "#24273A"
-set recolor-darkcolor		      "#CAD3F5"
+set recolor-lightcolor		    rgba(36,39,58,1)
+set recolor-darkcolor		      rgba(202,211,245,1)
 
-set index-fg			            "#CAD3F5"
-set index-bg			            "#24273A"
-set index-active-fg		        "#CAD3F5"
-set index-active-bg		        "#363A4F"
+set index-fg			            rgba(202,211,245,1)
+set index-bg			            rgba(36,39,58,1)
+set index-active-fg		        rgba(202,211,245,1)
+set index-active-bg		        rgba(54,58,79,1)
 
-set render-loading-bg		      "#24273A"
-set render-loading-fg		      "#CAD3F5"
+set render-loading-bg		      rgba(36,39,58,1)
+set render-loading-fg		      rgba(202,211,245,1)
 
-set highlight-color		        "#575268"
-set highlight-fg              "#F5BDE6"
-set highlight-active-color	  "#F5BDE6"
+set highlight-color		        rgba(87,82,104,0.5)
+set highlight-fg              rgba(245,189,230,0.5)
+set highlight-active-color	  rgba(245,189,230,0.5)

--- a/src/catppuccin-mocha
+++ b/src/catppuccin-mocha
@@ -1,38 +1,38 @@
-set default-fg                "#CDD6F4"
-set default-bg 			          "#1E1E2E"
+set default-fg                rgba(205,214,244,1)
+set default-bg 			          rgba(30,30,46,1)
 
-set completion-bg		          "#313244"
-set completion-fg		          "#CDD6F4"
-set completion-highlight-bg	  "#575268"
-set completion-highlight-fg	  "#CDD6F4"
-set completion-group-bg		    "#313244"
-set completion-group-fg		    "#89B4FA"
+set completion-bg		          rgba(49,50,68,1)
+set completion-fg		          rgba(205,214,244,1)
+set completion-highlight-bg	  rgba(87,82,104,1)
+set completion-highlight-fg	  rgba(205,214,244,1)
+set completion-group-bg		    rgba(49,50,68,1)
+set completion-group-fg		    rgba(137,180,250,1)
 
-set statusbar-fg		          "#CDD6F4"
-set statusbar-bg		          "#313244"
+set statusbar-fg		          rgba(205,214,244,1)
+set statusbar-bg		          rgba(49,50,68,1)
 
-set notification-bg		        "#313244"
-set notification-fg		        "#CDD6F4"
-set notification-error-bg	    "#313244"
-set notification-error-fg	    "#F38BA8"
-set notification-warning-bg	  "#313244"
-set notification-warning-fg	  "#FAE3B0"
+set notification-bg		        rgba(49,50,68,1)
+set notification-fg		        rgba(205,214,244,1)
+set notification-error-bg	    rgba(49,50,68,1)
+set notification-error-fg	    rgba(243,139,168,1)
+set notification-warning-bg	  rgba(49,50,68,1)
+set notification-warning-fg	  rgba(250,227,176,1)
 
-set inputbar-fg			          "#CDD6F4"
-set inputbar-bg 		          "#313244"
+set inputbar-fg			          rgba(205,214,244,1)
+set inputbar-bg 		          rgba(49,50,68,1)
 
 set recolor                   "true"
-set recolor-lightcolor		    "#1E1E2E"
-set recolor-darkcolor		      "#CDD6F4"
+set recolor-lightcolor		    rgba(30,30,46,1)
+set recolor-darkcolor		      rgba(205,214,244,1)
 
-set index-fg			            "#CDD6F4"
-set index-bg			            "#1E1E2E"
-set index-active-fg		        "#CDD6F4"
-set index-active-bg		        "#313244"
+set index-fg			            rgba(205,214,244,1)
+set index-bg			            rgba(30,30,46,1)
+set index-active-fg		        rgba(205,214,244,1)
+set index-active-bg		        rgba(49,50,68,1)
 
-set render-loading-bg		      "#1E1E2E"
-set render-loading-fg		      "#CDD6F4"
+set render-loading-bg		      rgba(30,30,46,1)
+set render-loading-fg		      rgba(205,214,244,1)
 
-set highlight-color		        "#575268"
-set highlight-fg              "#F5C2E7"
-set highlight-active-color	  "#F5C2E7"
+set highlight-color		        rgba(87,82,104,0.5)
+set highlight-fg              rgba(245,194,231,0.5)
+set highlight-active-color	  rgba(245,194,231,0.5)


### PR DESCRIPTION
I noticed that, at least for me, the highlight colors were not transparent and were thus obscuring the text I was searching for. I attempted to set the `highlight-transparency` variable to 0.5, which should be the default, but it didn't work. Using `rgba()` values did work, so I just converted everything with a script and set the highlight values to 50% transparency.